### PR TITLE
Default cfg override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ target_compile_definitions(${PROJECT_NAME}
     PRIVATE MDTOOL_VERSION_REVISION=${CMAKE_MATCH_3}
 )
 
-if(MAKE_TESTS)
+if(MAKE_TESTS_MDTOOL)
     add_subdirectory(test)
 endif()
 

--- a/include/ConfigManager.hpp
+++ b/include/ConfigManager.hpp
@@ -3,18 +3,39 @@
 #include <set>
 #include <string>
 
+
+/// @brief Class that manages the original and user motor config files directories
 class ConfigManager
 {
    public:
+   /// @brief Construct a new Config Manager object which right away scans and creates list of compared files in two directiories
+   /// @param originalConfigPath Path to the original (containing defaults) config directory
+   /// @param userConfigPath Path to the user config directory
 	ConfigManager(std::string originalConfigPath, std::string userConfigPath);
-	~ConfigManager();
+	~ConfigManager() = default;
 
+	/// @brief Performs the update on directories of compared files
+	/// @return Was the update successful
 	bool performUpdate();
+	/// @brief Get file names of files that are different
+	/// @return Set of file names
 	std::set<std::string> getDifferentFilePaths();
+	/// @brief Get file names of files that are identical
+	/// @return Set of file names
 	std::set<std::string> getIdenticalFilePaths();
+
 	bool static compareFiles(std::string originalFilePath, std::string userFilePath);
+
+	/// @brief Check if file exists
+	/// @param filePath - path to the file
+	/// @return True on file present, false otherwise
 	bool static doesFileExists(std::string filePath);
+	/// @brief Check if filename is present in original config directory set
+	/// @param configName - filename
+	/// @return True on present, false otherwise
 	bool isConfigDefault(std::string configName);
+	/// @brief Check if filename is in set that contains files that differ from the original defaults
+	/// @param configName - filename
 	bool isConifgDiffrent(std::string configName);
 
    private:

--- a/include/ConfigManager.hpp
+++ b/include/ConfigManager.hpp
@@ -14,6 +14,8 @@ class ConfigManager
 	std::set<std::string> getIdenticalFilePaths();
 	bool static compareFiles(std::string originalFilePath, std::string userFilePath);
 	bool static doesFileExists(std::string filePath);
+	bool isConfigDefault(std::string configName);
+	bool isConifgDiffrent(std::string configName);
 
    private:
 	std::set<std::string> differentFilePaths, identicalFilePaths, defaultFilenames;

--- a/include/ConfigManager.hpp
+++ b/include/ConfigManager.hpp
@@ -9,14 +9,17 @@ class ConfigManager
 	ConfigManager(std::string originalConfigPath, std::string userConfigPath);
 	~ConfigManager();
 
+	bool performUpdate();
 	std::set<std::string> getDifferentFilePaths();
 	std::set<std::string> getIdenticalFilePaths();
-	bool static compareFiles(std::string originalFile, std::string userFile);
+	bool static compareFiles(std::string originalFilePath, std::string userFilePath);
+	bool static doesFileExists(std::string filePath);
 
    private:
-	std::set<std::string> differentFilePaths;
-	std::set<std::string> identicalFilePaths;
-	std::set<std::string> defaultFilenames;
+	std::set<std::string> differentFilePaths, identicalFilePaths, defaultFilenames;
 
-	void update(std::string originalConfigPath, std::string userConfigPath);
+	std::string originalConfigPath, userConfigPath;
+
+	void update();
+
 };

--- a/include/ConfigManager.hpp
+++ b/include/ConfigManager.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <set>
+#include <string>
+
+class ConfigManager
+{
+   public:
+	ConfigManager(std::string originalConfigPath, std::string userConfigPath);
+	~ConfigManager();
+
+	std::set<std::string> getDifferentFilePaths();
+	std::set<std::string> getIdenticalFilePaths();
+	bool static compareFiles(std::string originalFile, std::string userFile);
+
+   private:
+	std::set<std::string> differentFilePaths;
+	std::set<std::string> identicalFilePaths;
+	std::set<std::string> defaultFilenames;
+
+	void update(std::string originalConfigPath, std::string userConfigPath);
+};

--- a/include/ConfigManager.hpp
+++ b/include/ConfigManager.hpp
@@ -3,14 +3,13 @@
 #include <set>
 #include <string>
 
-
 /// @brief Class that manages the original and user motor config files directories
 class ConfigManager
 {
    public:
-   /// @brief Construct a new Config Manager object which right away scans and creates list of compared files in two directiories
-   /// @param originalConfigPath Path to the original (containing defaults) config directory
-   /// @param userConfigPath Path to the user config directory
+	/// @brief Construct a new Config Manager object which right away scans and creates list of compared files in two directiories
+	/// @param originalConfigPath Path to the original (containing defaults) config directory
+	/// @param userConfigPath Path to the user config directory
 	ConfigManager(std::string originalConfigPath, std::string userConfigPath);
 	~ConfigManager() = default;
 
@@ -44,5 +43,4 @@ class ConfigManager
 	std::string originalConfigPath, userConfigPath;
 
 	void update();
-
 };

--- a/include/ui.hpp
+++ b/include/ui.hpp
@@ -50,6 +50,8 @@ void printErrorDetails(uint32_t error, const std::map<std::string, uint8_t>& err
 void printParameterOutOfBounds(std::string category, std::string field);
 void printFailedToSetupMotor(mab::Md80Reg_E regId);
 
+bool getDiffrentConfigsConfirmation(std::string configName);
+
 /* these are only used to light up the values in */
 constexpr float outputEncoderStdDevMax = 0.05f;
 constexpr float outputEncoderMaxError = 0.18f;

--- a/launch/buildAndTest.bash
+++ b/launch/buildAndTest.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+cd ..
+mkdir build
+cd build
+cmake .. -DMAKE_TESTS_MDTOOL=ON
+make -j
+cd test
+./mdtool_test

--- a/launch/buildAndTest.bash
+++ b/launch/buildAndTest.bash
@@ -4,6 +4,11 @@ cd ..
 mkdir build
 cd build
 cmake .. -DMAKE_TESTS_MDTOOL=ON
-make -j
+if make -j ; then
+    echo "Build successful"
+else
+    echo "Build failed"
+    exit 1
+fi
 cd test
 ./mdtool_test

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -1,82 +1,114 @@
 #include "ConfigManager.hpp"
-#include "mini/ini.h"
-#include "dirent.h"
 
 #include <iostream>
 
-ConfigManager::ConfigManager(std::string originalConfigPath, std::string userConfigPath)
+#include "dirent.h"
+#include "mini/ini.h"
+
+ConfigManager::ConfigManager(std::string originalConfigPath, std::string userConfigPath) :
+    originalConfigPath(originalConfigPath),
+    userConfigPath(userConfigPath)
 {
-    update(originalConfigPath, userConfigPath);
+	update();
 }
 
 ConfigManager::~ConfigManager()
 {
 }
 
-void ConfigManager::update(std::string originalConfigPath, std::string userConfigPath)
+void ConfigManager::update()
 {
-    // Clear the sets
-    differentFilePaths.clear();
-    identicalFilePaths.clear();
-    defaultFilenames.clear();
+	// Clear the sets
+	differentFilePaths.clear();
+	identicalFilePaths.clear();
+	defaultFilenames.clear();
 
+	// Get the filenames of the original config
+	DIR* dir;
+	struct dirent* ent;
+	if ((dir = opendir(originalConfigPath.c_str())) != NULL)
+	{
+		while ((ent = readdir(dir)) != NULL)
+		{
+			std::string filename = ent->d_name;
+			if (filename != "." && filename != "..")
+			{
+				defaultFilenames.insert(filename);
+			}
+		}
+		closedir(dir);
+	}
+	else
+	{
+		exit(18886);
+	}
 
-    // Get the filenames of the original config
-    DIR *dir;
-    struct dirent *ent;
-    if ((dir = opendir(originalConfigPath.c_str())) != NULL)
-    {
-        while ((ent = readdir(dir)) != NULL)
-        {
-            std::string filename = ent->d_name;
-            if (filename != "." && filename != "..")
-            {
-                defaultFilenames.insert(filename);
-            }
-        }
-        closedir(dir);
-    }
-    else
-    {
-        exit(18886);
-    }
+	// Compare the files
+	for (auto& filename : defaultFilenames)
+	{
+		std::string originalFile = originalConfigPath + filename;
+		std::string userFile = userConfigPath + filename;
 
-    // Compare the files
-    for (auto &filename : defaultFilenames)
-    {
-        std::string originalFile = originalConfigPath + filename;
-        std::string userFile = userConfigPath + filename;
-
-
-        if (compareFiles(originalFile, userFile))
-        {
-            identicalFilePaths.insert(filename);
-        }
-        else
-        {
-            differentFilePaths.insert(filename);
-        }
-    }        
+		if (compareFiles(originalFile, userFile))
+		{
+			identicalFilePaths.insert(filename);
+		}
+		else
+		{
+			differentFilePaths.insert(filename);
+		}
+	}
 }
 
 bool ConfigManager::compareFiles(std::string originalFilePath, std::string userFilePath)
 {
-    std::fstream originalFileStream(originalFilePath);
-    std::fstream userFileStream(userFilePath);
+	// check if files exist
+	if (!doesFileExists(originalFilePath))
+	{
+		std::cout << "Original file path doesn't exist" << std::endl;
+		return false;
+	}
 
-    std::string originalFile((std::istreambuf_iterator<char>(originalFileStream)), std::istreambuf_iterator<char>());
-    std::string userFile((std::istreambuf_iterator<char>(userFileStream)), std::istreambuf_iterator<char>());
+	if (!doesFileExists(userFilePath))
+	{
+		std::cout << "User file path doesn't exist" << std::endl;
+		return false;
+	}
 
-    std::hash<std::string> hasher;
+	std::fstream originalFileStream(originalFilePath, std::ios::in);
+	std::fstream userFileStream(userFilePath, std::ios::in);
 
-    return hasher(originalFile) == hasher(userFile);
+	if (!originalFileStream.is_open() || !userFileStream.is_open())
+	{
+		std::cout << "Error opening file" << std::endl;
+		return false;
+	}
+
+	std::string originalFile((std::istreambuf_iterator<char>(originalFileStream)), std::istreambuf_iterator<char>());
+	std::string userFile((std::istreambuf_iterator<char>(userFileStream)), std::istreambuf_iterator<char>());
+
+	std::hash<std::string> hasher;
+
+	return hasher(originalFile) == hasher(userFile);
+}
+
+bool ConfigManager::doesFileExists(std::string filePath)
+{
+	std::ifstream fileStream(filePath);
+	return fileStream.good();
 }
 
 std::set<std::string> ConfigManager::getDifferentFilePaths()
 {
-    return differentFilePaths;
+	return differentFilePaths;
 }
 std::set<std::string> ConfigManager::getIdenticalFilePaths()
 {
-    return identicalFilePaths;
+	return identicalFilePaths;
+}
+
+bool ConfigManager::performUpdate()
+{
+    this->update();
+    return true;
 }

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -38,7 +38,6 @@ void ConfigManager::update()
 		exit(18886);
 	}
 
-	// Compare the files
 	for (auto& filename : defaultFilenames)
 	{
 		std::string originalFile = originalConfigPath + "/" + filename;

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -1,0 +1,82 @@
+#include "ConfigManager.hpp"
+#include "mini/ini.h"
+#include "dirent.h"
+
+#include <iostream>
+
+ConfigManager::ConfigManager(std::string originalConfigPath, std::string userConfigPath)
+{
+    update(originalConfigPath, userConfigPath);
+}
+
+ConfigManager::~ConfigManager()
+{
+}
+
+void ConfigManager::update(std::string originalConfigPath, std::string userConfigPath)
+{
+    // Clear the sets
+    differentFilePaths.clear();
+    identicalFilePaths.clear();
+    defaultFilenames.clear();
+
+
+    // Get the filenames of the original config
+    DIR *dir;
+    struct dirent *ent;
+    if ((dir = opendir(originalConfigPath.c_str())) != NULL)
+    {
+        while ((ent = readdir(dir)) != NULL)
+        {
+            std::string filename = ent->d_name;
+            if (filename != "." && filename != "..")
+            {
+                defaultFilenames.insert(filename);
+            }
+        }
+        closedir(dir);
+    }
+    else
+    {
+        exit(18886);
+    }
+
+    // Compare the files
+    for (auto &filename : defaultFilenames)
+    {
+        std::string originalFile = originalConfigPath + filename;
+        std::string userFile = userConfigPath + filename;
+
+
+        if (compareFiles(originalFile, userFile))
+        {
+            identicalFilePaths.insert(filename);
+        }
+        else
+        {
+            differentFilePaths.insert(filename);
+        }
+    }        
+}
+
+bool ConfigManager::compareFiles(std::string originalFilePath, std::string userFilePath)
+{
+    std::fstream originalFileStream(originalFilePath);
+    std::fstream userFileStream(userFilePath);
+
+    std::string originalFile((std::istreambuf_iterator<char>(originalFileStream)), std::istreambuf_iterator<char>());
+    std::string userFile((std::istreambuf_iterator<char>(userFileStream)), std::istreambuf_iterator<char>());
+
+    std::hash<std::string> hasher;
+
+    return hasher(originalFile) == hasher(userFile);
+}
+
+std::set<std::string> ConfigManager::getDifferentFilePaths()
+{
+    return differentFilePaths;
+}
+std::set<std::string> ConfigManager::getIdenticalFilePaths()
+{
+    return identicalFilePaths;
+}

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -87,9 +87,7 @@ bool ConfigManager::compareFiles(std::string originalFilePath, std::string userF
 	std::string originalFile((std::istreambuf_iterator<char>(originalFileStream)), std::istreambuf_iterator<char>());
 	std::string userFile((std::istreambuf_iterator<char>(userFileStream)), std::istreambuf_iterator<char>());
 
-	std::hash<std::string> hasher;
-
-	return hasher(originalFile) == hasher(userFile);
+	return originalFile == userFile;
 }
 
 bool ConfigManager::doesFileExists(std::string filePath)

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -5,9 +5,8 @@
 #include "dirent.h"
 #include "mini/ini.h"
 
-ConfigManager::ConfigManager(std::string originalConfigPath, std::string userConfigPath) :
-    originalConfigPath(originalConfigPath),
-    userConfigPath(userConfigPath)
+ConfigManager::ConfigManager(std::string originalConfigPath, std::string userConfigPath) : originalConfigPath(originalConfigPath),
+																						   userConfigPath(userConfigPath)
 {
 	update();
 }
@@ -103,23 +102,23 @@ std::set<std::string> ConfigManager::getIdenticalFilePaths()
 
 bool ConfigManager::performUpdate()
 {
-    this->update();
-    return true;
+	this->update();
+	return true;
 }
 
 bool ConfigManager::isConfigDefault(std::string configName)
 {
-    return defaultFilenames.find(configName) != defaultFilenames.end();
+	return defaultFilenames.find(configName) != defaultFilenames.end();
 }
 
 bool ConfigManager::isConifgDiffrent(std::string configName)
 {
-    if (!isConfigDefault(configName))
-    {
-        return false;
-    }
-    else 
-    {
-        return differentFilePaths.find(configName) != differentFilePaths.end();
-    }
+	if (!isConfigDefault(configName))
+	{
+		return false;
+	}
+	else
+	{
+		return differentFilePaths.find(configName) != differentFilePaths.end();
+	}
 }

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -46,8 +46,8 @@ void ConfigManager::update()
 	// Compare the files
 	for (auto& filename : defaultFilenames)
 	{
-		std::string originalFile = originalConfigPath + filename;
-		std::string userFile = userConfigPath + filename;
+		std::string originalFile = originalConfigPath + "/" + filename;
+		std::string userFile = userConfigPath + "/" + filename;
 
 		if (compareFiles(originalFile, userFile))
 		{
@@ -111,4 +111,21 @@ bool ConfigManager::performUpdate()
 {
     this->update();
     return true;
+}
+
+bool ConfigManager::isConfigDefault(std::string configName)
+{
+    return defaultFilenames.find(configName) != defaultFilenames.end();
+}
+
+bool ConfigManager::isConifgDiffrent(std::string configName)
+{
+    if (!isConfigDefault(configName))
+    {
+        return false;
+    }
+    else 
+    {
+        return differentFilePaths.find(configName) != differentFilePaths.end();
+    }
 }

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -12,10 +12,6 @@ ConfigManager::ConfigManager(std::string originalConfigPath, std::string userCon
 	update();
 }
 
-ConfigManager::~ConfigManager()
-{
-}
-
 void ConfigManager::update()
 {
 	// Clear the sets

--- a/src/mainWorker.cpp
+++ b/src/mainWorker.cpp
@@ -138,25 +138,6 @@ MainWorker::MainWorker(std::vector<std::string>& args)
 	mdtoolBaseDir = std::string(getenv("HOME")) + "/" + mdtoolHomeConfigDirName + "/" + mdtoolDirName;
 	mdtoolIniFilePath = mdtoolBaseDir + "/" + mdtoolIniFileName;
 
-	ConfigManager configManager(mdtoolConfigPath + "/" + mdtoolDirName + "/" + mdtoolMotorCfgDirName ,mdtoolBaseDir + "/" + mdtoolMotorCfgDirName);
-
-	std::cout << "Original path: " << mdtoolConfigPath + mdtoolDirName + "/" + mdtoolMotorCfgDirName << std::endl;
-	std::cout << "User path: " << mdtoolBaseDir + "/" + mdtoolMotorCfgDirName << std::endl;
-
-	auto identicalFiles = configManager.getIdenticalFilePaths();
-	std::cout << "IDENTICAL FILES: " << std::endl << "================" << std::endl;
-	for (auto& file : identicalFiles)
-	{
-		std::cout << file << std::endl;
-	}
-	auto differentFiles = configManager.getDifferentFilePaths();
-	std::cout << std::endl << std::endl;
-	std::cout << "DIFFERENT FILES: " << std::endl << "================" << std::endl;
-	for (auto& file : differentFiles)
-	{
-		std::cout << file << std::endl;
-	}
-
 
 	/* copy motors configs directory - not the best practice to use system() but std::filesystem is not available until C++17 */
 	struct stat info;
@@ -177,8 +158,8 @@ MainWorker::MainWorker(std::vector<std::string>& args)
 			ini["general"]["version"] = getVersion();
 			file.write(ini);
 		}
-
-		result = system(("cp -a " + mdtoolConfigPath + mdtoolDirName + "/" + mdtoolMotorCfgDirName + "/." + " " + mdtoolBaseDir + "/" + mdtoolMotorCfgDirName + "/").c_str());
+		//deprecated becouse it always ovewrtitten the config files
+		//result = system(("cp -a " + mdtoolConfigPath + mdtoolDirName + "/" + mdtoolMotorCfgDirName + "/." + " " + mdtoolBaseDir + "/" + mdtoolMotorCfgDirName + "/").c_str());
 	}
 
 	/* defaults */
@@ -466,6 +447,19 @@ void MainWorker::setupMotor(std::vector<std::string>& args)
 	if (id == -1) return;
 
 	std::string path = (mdtoolBaseDir + "/" + mdtoolMotorCfgDirName + "/" + args[4].c_str());
+
+	std::string filename = args[4].c_str();
+
+	ConfigManager configManager(mdtoolConfigPath + mdtoolDirName + "/" + mdtoolMotorCfgDirName, mdtoolBaseDir + "/" + mdtoolMotorCfgDirName);
+
+	if(configManager.isConfigDefault(filename) && configManager.isConifgDiffrent(filename))
+	{
+		if (ui::getDiffrentConfigsConfirmation(filename))
+		{
+			system(("cp " + mdtoolConfigPath + mdtoolDirName + "/" + mdtoolMotorCfgDirName + "/" + filename + " " + mdtoolBaseDir + "/" + mdtoolMotorCfgDirName + "/" + filename).c_str());
+		}
+			
+	}
 
 	mINI::INIFile motorCfg(path);
 	mINI::INIStructure cfg;

--- a/src/mainWorker.cpp
+++ b/src/mainWorker.cpp
@@ -157,8 +157,6 @@ MainWorker::MainWorker(std::vector<std::string>& args)
 			ini["general"]["version"] = getVersion();
 			file.write(ini);
 		}
-		//deprecated becouse it always ovewrtitten the config files
-		//result = system(("cp -a " + mdtoolConfigPath + mdtoolDirName + "/" + mdtoolMotorCfgDirName + "/." + " " + mdtoolBaseDir + "/" + mdtoolMotorCfgDirName + "/").c_str());
 	}
 
 	/* defaults */

--- a/src/mainWorker.cpp
+++ b/src/mainWorker.cpp
@@ -138,7 +138,6 @@ MainWorker::MainWorker(std::vector<std::string>& args)
 	mdtoolBaseDir = std::string(getenv("HOME")) + "/" + mdtoolHomeConfigDirName + "/" + mdtoolDirName;
 	mdtoolIniFilePath = mdtoolBaseDir + "/" + mdtoolIniFileName;
 
-
 	/* copy motors configs directory - not the best practice to use system() but std::filesystem is not available until C++17 */
 	struct stat info;
 	int result = 0;

--- a/src/mainWorker.cpp
+++ b/src/mainWorker.cpp
@@ -6,6 +6,7 @@
 #include <numeric>
 
 #include "ui.hpp"
+#include "ConfigManager.hpp"
 
 enum class toolsCmd_E
 {
@@ -136,6 +137,26 @@ MainWorker::MainWorker(std::vector<std::string>& args)
 {
 	mdtoolBaseDir = std::string(getenv("HOME")) + "/" + mdtoolHomeConfigDirName + "/" + mdtoolDirName;
 	mdtoolIniFilePath = mdtoolBaseDir + "/" + mdtoolIniFileName;
+
+	ConfigManager configManager(mdtoolConfigPath + "/" + mdtoolDirName + "/" + mdtoolMotorCfgDirName ,mdtoolBaseDir + "/" + mdtoolMotorCfgDirName);
+
+	std::cout << "Original path: " << mdtoolConfigPath + mdtoolDirName + "/" + mdtoolMotorCfgDirName << std::endl;
+	std::cout << "User path: " << mdtoolBaseDir + "/" + mdtoolMotorCfgDirName << std::endl;
+
+	auto identicalFiles = configManager.getIdenticalFilePaths();
+	std::cout << "IDENTICAL FILES: " << std::endl << "================" << std::endl;
+	for (auto& file : identicalFiles)
+	{
+		std::cout << file << std::endl;
+	}
+	auto differentFiles = configManager.getDifferentFilePaths();
+	std::cout << std::endl << std::endl;
+	std::cout << "DIFFERENT FILES: " << std::endl << "================" << std::endl;
+	for (auto& file : differentFiles)
+	{
+		std::cout << file << std::endl;
+	}
+
 
 	/* copy motors configs directory - not the best practice to use system() but std::filesystem is not available until C++17 */
 	struct stat info;

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -423,16 +423,16 @@ void printFailedToSetupMotor(mab::Md80Reg_E regId)
 
 bool getDiffrentConfigsConfirmation(std::string configName)
 {
-	vout << "You config " << configName << " is diffrent than default one." << std::endl;
-	vout << "Do you revert it to default? [Y/n]" << std::endl;
+	vout << "[MDTOOL] The default " << configName << " config was modified." << std::endl;
+	vout << "[MDTOOL] Would you like to revert it to default before downloading? [Y/n]" << std::endl;
 	char x;
 	std::cin >> x;
 	if (x != 'Y')
 	{
-		vout << "Using user-changed config." << std::endl;
+		vout << "[MDTOOL] Using modified config." << std::endl;
 		return false;
 	}
-	vout << "Reverting to default config." << std::endl;
+	vout << "[MDTOOL] Using default config." << std::endl;
 	return true;
 
 }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -421,4 +421,20 @@ void printFailedToSetupMotor(mab::Md80Reg_E regId)
 	vout << "Failed to setup motor! Error while writing: 0x" << std::hex << static_cast<uint16_t>(regId) << " register" << std::endl;
 }
 
+bool getDiffrentConfigsConfirmation(std::string configName)
+{
+	vout << "You config " << configName << " is diffrent than default one." << std::endl;
+	vout << "Do you revert it to default? [Y/n]" << std::endl;
+	char x;
+	std::cin >> x;
+	if (x != 'Y')
+	{
+		vout << "Using user-changed config." << std::endl;
+		return false;
+	}
+	vout << "Reverting to default config." << std::endl;
+	return true;
+
+}
+
 }  // namespace ui

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,10 +8,12 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(googletest)
 add_library(GTest::GTest INTERFACE IMPORTED)
 
+file (GLOB_RECURSE TEST_SOURCES CONFIGURE_DEPENDS "*.cpp")
+
 include_directories(mdtool_test ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/candle/include ${CMAKE_SOURCE_DIR}/3rd_party/mINI/src)
 target_link_libraries(GTest::GTest INTERFACE gtest_main)
 
-add_executable(mdtool_test test.cpp ${CMAKE_SOURCE_DIR}/src/ui.cpp)
+add_executable(mdtool_test ${CMAKE_SOURCE_DIR}/src/ui.cpp ${TEST_SOURCES} ${CMAKE_SOURCE_DIR}/src/ConfigManager.cpp)
 
 target_link_libraries(mdtool_test
     PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,7 @@
 include(FetchContent)
 
+enable_testing()
+
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -1,21 +1,88 @@
 #include "ConfigManager.hpp"
 
 #include <gtest/gtest.h>
+#include <fstream>
 
-class ConfiManagetTest : public ::testing::Test
+class ConfigManagerTest : public ::testing::Test
 {
     protected:
     virtual void SetUp()
     {
+        //Create two test files
+        std::ofstream file1(tempfile1Path);
+        file1 << "This is a test file";
+        file1.close();
+        std::ofstream file2(tempfile2Path);
+        file2 << "This is a test file 2";
+        file2.close();
+        std::ofstream file3(tempfile3Path);
+        file3 << "This is a test file 3";
+        file3.close();
+
+        system(("mkdir " + tempOriginalDirectory).c_str());
+        system(("mkdir " + tempUserDirectory).c_str());
+
+        //Copy the test file to the original directory
+        system(("cp " + tempfile1Path + " " + tempOriginalDirectory).c_str());
+        system(("cp " + tempfile2Path + " " + tempOriginalDirectory).c_str());
+        
+        //Copy the test file to the user directory
+        system(("cp " + tempfile1Path + " " + tempUserDirectory).c_str());
+        system(("cp " + tempfile2Path + " " + tempUserDirectory).c_str());
+        system(("cp " + tempfile3Path + " " + tempUserDirectory).c_str());
+
     }
 
     virtual void TearDown()
     {
+        // //Delete the test files
+        remove(tempfile1Path.c_str());
+        remove(tempfile2Path.c_str());
+        remove(tempfile3Path.c_str());
+
+        // //Delete the test directories
+        system(("rm -rf " + tempOriginalDirectory).c_str());
+        system(("rm -rf " + tempUserDirectory).c_str());
     }
+
+    std::string tempOriginalDirectory = "./original/";
+    std::string tempUserDirectory = "./user/";
+
+    std::string tempfile1Path = "asepoawinoeaine.txt";
+    std::string tempfile2Path = "aweradswaeawesdae.txt";
+    std::string tempfile3Path = "awerasdawsdae.txt";
 };
 
-TEST_F(ConfiManagetTest, FileCompareTest)
+TEST_F(ConfigManagerTest, FileCompareTest)
 {
-    ASSERT_EQ(ConfigManager::compareFiles("test/ConfigManagerTest.cpp", "test/ConfigManagerTest.cpp"), true);
-    ASSERT_EQ(ConfigManager::compareFiles("test/ConfigManagerTest.cpp", "test/test.cpp"), false);
+    ASSERT_EQ(ConfigManager::compareFiles(tempfile1Path, tempfile1Path), true);
+    ASSERT_EQ(ConfigManager::compareFiles(tempfile1Path, tempfile2Path), false);
+}
+
+TEST_F(ConfigManagerTest, ReadFileTest)
+{
+    ASSERT_EQ(ConfigManager::doesFileExists(tempfile2Path), true);
+    ASSERT_EQ(ConfigManager::doesFileExists("./asfaewawedddddddea.cpp"), false);
+}
+
+TEST_F(ConfigManagerTest, CompareOnlyOriginalFilesInDirectory)
+{
+    ConfigManager configManager(tempOriginalDirectory, tempUserDirectory);
+    ASSERT_EQ(configManager.getIdenticalFilePaths().size(), 2);
+    ASSERT_EQ(configManager.getDifferentFilePaths().size(), 0);
+
+    //change file to check if it is detected
+    std::ofstream file1(tempUserDirectory + tempfile1Path);
+    file1 << "This is again a test file but diffrent";
+    file1.close();
+
+    configManager.performUpdate();
+    ASSERT_EQ(configManager.getIdenticalFilePaths().size(), 1);
+    ASSERT_EQ(configManager.getDifferentFilePaths().size(), 1);
+    ASSERT_EQ(configManager.getDifferentFilePaths().find(tempUserDirectory + tempfile1Path) != configManager.getDifferentFilePaths().end(), true);
+    
+    //revert file to original
+    file1.open(tempUserDirectory + tempfile1Path);
+    file1 << "This is a test file";
+    file1.close();
 }

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -1,0 +1,21 @@
+#include "ConfigManager.hpp"
+
+#include <gtest/gtest.h>
+
+class ConfiManagetTest : public ::testing::Test
+{
+    protected:
+    virtual void SetUp()
+    {
+    }
+
+    virtual void TearDown()
+    {
+    }
+};
+
+TEST_F(ConfiManagetTest, FileCompareTest)
+{
+    ASSERT_EQ(ConfigManager::compareFiles("test/ConfigManagerTest.cpp", "test/ConfigManagerTest.cpp"), true);
+    ASSERT_EQ(ConfigManager::compareFiles("test/ConfigManagerTest.cpp", "test/test.cpp"), false);
+}

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -79,10 +79,25 @@ TEST_F(ConfigManagerTest, CompareOnlyOriginalFilesInDirectory)
     configManager.performUpdate();
     ASSERT_EQ(configManager.getIdenticalFilePaths().size(), 1);
     ASSERT_EQ(configManager.getDifferentFilePaths().size(), 1);
-    ASSERT_EQ(configManager.getDifferentFilePaths().find(tempUserDirectory + tempfile1Path) != configManager.getDifferentFilePaths().end(), true);
+    ASSERT_EQ(configManager.getDifferentFilePaths().find(tempfile1Path) != configManager.getDifferentFilePaths().end(), true);
     
     //revert file to original
     file1.open(tempUserDirectory + tempfile1Path);
     file1 << "This is a test file";
     file1.close();
+}
+
+TEST_F(ConfigManagerTest, IsConfigValidAndDiffrent)
+{
+    //change file
+    std::ofstream file1(tempUserDirectory + tempfile1Path);
+    file1 << "This is again a test file but diffrent";
+    file1.close();
+
+    ConfigManager configManager(tempOriginalDirectory, tempUserDirectory);
+    ASSERT_EQ(configManager.isConfigDefault(tempfile1Path), true);
+    ASSERT_EQ(configManager.isConfigDefault("aweasdassddddddddddddddd"), false);
+    ASSERT_EQ(configManager.isConifgDiffrent(tempfile1Path), true);
+    ASSERT_EQ(configManager.isConifgDiffrent(tempfile2Path), false);
+
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -2,12 +2,6 @@
 
 #include "ui.hpp"
 
-TEST(mdtoolTest, Test_Dummy)
-{
-	ui::printHelp();
-	ASSERT_EQ(1, true);
-}
-
 int main(int argc, char** argv)
 {
 	::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Feature enabling users to have control over how default configs are treated. On "setup motor" command a difference check runs and prompts user. User can choose between overwriting their changes, thus reverting to default, or using their config. 