### PR TITLE
Calibrated report encoder

### DIFF
--- a/include/ui.hpp
+++ b/include/ui.hpp
@@ -60,7 +60,7 @@ constexpr float mainEncoderStdDevMax = 0.012f;
 constexpr float mainEncoderMaxError = 0.05f;
 
 const std::vector<std::string> encoderTypes = {"NONE", "AS5047_CENTER", "AS5047_OFFAXIS", "MB053SFA17BENT00", "CM_OFFAXIS", "M24B_CENTER", "M24B_OFFAXIS"};
-const std::vector<std::string> encoderModes = {"NONE", "STARTUP", "MOTION", "REPORT", "MAIN"};
+const std::vector<std::string> encoderModes = {"NONE", "STARTUP", "MOTION", "REPORT", "MAIN","CALIBRATED_REPORT"};
 const std::vector<std::string> encoderCalibrationModes = {"FULL", "DIRONLY"};
 const std::vector<std::string> motorCalibrationModes = {"FULL", "NOPPDET"};
 const std::vector<std::string> homingModes = {"OFF", "SENSORLESS"};

--- a/template_package/etc/mdtool/mdtool_motors/AK60-6.cfg
+++ b/template_package/etc/mdtool/mdtool_motors/AK60-6.cfg
@@ -34,7 +34,7 @@ velocity = 20.0
 [output encoder]
 # output encoder type - valid types: AS5047_CENTER, AS5047_OFFAXIS, MB053SFA17BENT00, CM_OFFAXIS
 output encoder = 0
-# output encoder mode - valid modes: STARTUP, MOTION, REPORT
+# output encoder mode - valid modes: STARTUP, MOTION, CALIBRATED_REPORT
 output encoder mode = 0
 
 [position PID]


### PR DESCRIPTION
New calibration mode support "CALIBRATED_REPORT", it works exactly like startup except that it does not affect position readings of the main encoder.